### PR TITLE
Fix JSON

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -9,7 +9,7 @@
 	"license-name": "GPL-2.0",
 	"type": "other",
 	"AutoloadClasses": {
-		"RomanianDiacriticsReplacements": "RomanianDiacriticsReplacements_body.php",
+		"RomanianDiacriticsReplacements": "RomanianDiacriticsReplacements_body.php"
 	},
 	"config": {
 	},
@@ -25,4 +25,3 @@
 	},
 	"manifest_version": 1
 }
-

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,3 +1,3 @@
 {
-	'rodia-config': 'MediaWiki:DiacriticsTemplates',
+	"rodia-config": "MediaWiki:DiacriticsTemplates"
 }


### PR DESCRIPTION
JSON files are now enclosed by double quotes and without
trailing comma per RFC 7159 standard.
